### PR TITLE
Implement Dark Mode with Orange Accent Theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+base = "dark"
+primaryColor = "#FF8C00" # DarkOrange
+# backgroundColor = "#1E1E1E" # Optionally uncomment and adjust if needed
+# secondaryBackgroundColor = "#2C2C2C" # Optionally uncomment and adjust if needed
+# textColor = "#FFFFFF" # Optionally uncomment and adjust if needed

--- a/app.py
+++ b/app.py
@@ -50,6 +50,17 @@ st.set_page_config(
     initial_sidebar_state="expanded"
 )
 
+# Functie om aangepaste CSS te laden
+def load_custom_css():
+    """Laadt aangepaste CSS uit static/style.css en past deze toe."""
+    css_file_path = os.path.join("static", "style.css")
+    if os.path.exists(css_file_path):
+        with open(css_file_path, "r") as f:
+            css_content = f.read()
+        st.markdown(f'<style>{css_content}</style>', unsafe_allow_html=True)
+    else:
+        st.warning("Aangepast CSS-bestand (style.css) niet gevonden in de map 'static'.")
+
 def display_field_info(field):
     """Toon veldinformatie in een leesbaar formaat"""
     col1, col2, col3 = st.columns(3)
@@ -349,6 +360,10 @@ def main():
     st.markdown("---")
     st.caption("Tableau Analyzer - Gemaakt met Streamlit")
 
+# De display_datasource, display_worksheet, display_dashboard functies zijn hieronder
+# ongewijzigd gebleven, maar voor de duidelijkheid van de diff hier ingekort.
+# Zorg ervoor dat ze in de uiteindelijke code aanwezig zijn.
+
 def display_datasource(bron):
     """Toon details van een databron"""
     with st.expander(f"🔌 {bron.get('naam', 'Onbekende bron')}"):
@@ -428,4 +443,5 @@ def display_dashboard(db):
             st.dataframe(pd.DataFrame(objecten))
 
 if __name__ == "__main__":
+    load_custom_css() # Laad CSS voordat de rest van de app wordt getekend
     main()

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,48 @@
+/* General body text if needed, though Streamlit's base dark theme should handle this */
+body {
+    color: #EAEAEA; /* Light gray for text on dark background */
+}
+
+/* Streamlit expander styling */
+.stApp [data-testid="stExpander"] > div:first-child { /* Expander header */
+    background-color: #2C2C2C; /* Darker gray for expander header */
+    border-radius: 0.5rem;
+}
+.stApp [data-testid="stExpander"] > div:first-child details summary:hover {
+     background-color: #3A3A3A; /* Slightly lighter gray on hover */
+}
+.stApp [data-testid="stExpander"] > div:first-child details summary p { /* Expander title text */
+    color: #FF8C00; /* Orange for expander titles */
+    font-weight: bold;
+}
+
+/* Styling for Pandas DataFrames (tables) */
+.stDataFrame table {
+    border: 1px solid #FF8C00; /* Orange border for table */
+}
+.stDataFrame th { /* Table headers */
+    background-color: #FF8C00; /* Orange background for headers */
+    color: #FFFFFF; /* White text on orange headers */
+}
+.stDataFrame td { /* Table cells */
+    border-color: #2C2C2C; /* Dark gray for cell borders */
+}
+
+/* Custom styling for Streamlit buttons if primaryColor isn't enough */
+/* This rule targets the default button. Be careful if you have different button types. */
+.stButton>button {
+    border: 1px solid #FF8C00;
+    /* The primaryColor from config.toml should handle background and text color for the main button.
+       This CSS adds an orange border. If more specific styling is needed (e.g., for secondary buttons
+       that don't pick up primaryColor), more specific selectors would be required. */
+}
+
+/* Styling for code blocks */
+/* Streamlit's dark theme usually handles code blocks well. These are overrides if needed. */
+.stCodeBlock > div { /* Target the container of the code */
+    background-color: #2C2C2C !important;
+}
+.stCodeBlock code, .stCodeBlock pre {
+    background-color: #2C2C2C !important; /* Ensure dark background for code */
+    color: #EAEAEA !important; /* Light text for code */
+}


### PR DESCRIPTION
This commit introduces a dark mode theme with an orange accent to the Tableau Workbook Analyzer, enhancing its visual appeal.

Key changes:

1.  **Streamlit Native Theming (`.streamlit/config.toml`):**
    *   A `config.toml` file was added to define the core theme.
    *   Set `base = "dark"` to leverage Streamlit's built-in dark theme.
    *   Set `primaryColor = "#FF8C00"` (DarkOrange) to apply an orange accent to interactive UI elements (buttons, tabs, etc.).

2.  **Custom CSS for Fine-tuning (`static/style.css`):**
    *   A `static/style.css` file was created to provide more granular control over specific UI elements.
    *   Custom styles were added for:
        *   Expander headers (dark background, orange titles).
        *   Pandas DataFrames (orange borders and headers).
        *   Button borders (orange).
        *   Code blocks (dark background, light text).
    *   `app.py` was updated to load this custom CSS file.

3.  **Consistent Application:**
    *   The theme is expected to apply consistently across major UI components, including text, backgrounds, interactive widgets, tables, and expanders.

This theming provides a more modern and visually engaging user experience. Further minor adjustments can be made after visual review if needed.